### PR TITLE
User management

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ required for completing the challenge.
 * [x] Search contents of notes with keywords
 * [x] Notes can be either public or private
     * Public notes can be viewed without authentication, however they cannot be modified
-* [ ] User management API to create new users
+* [x] User management API to create new users
 
 ### Limitations:
 

--- a/app/notes/permissions.py
+++ b/app/notes/permissions.py
@@ -10,9 +10,11 @@ class IsAuthenticatedOrPublic(BasePermission):
         return False
 
 
-class IsSelf(BasePermission):
+class UserPermission(BasePermission):
     def has_permission(self, request, view):
         if request.method in SAFE_METHODS:
+            return True
+        if request.method == "POST" and not request.user.is_authenticated:
             return True
         return False
 

--- a/app/notes/serializers.py
+++ b/app/notes/serializers.py
@@ -1,12 +1,23 @@
 from django.contrib.auth.models import User
+from django.contrib.auth.hashers import make_password
 from rest_framework import serializers
 from .models import Note, Tag
 
 
 class UserSerializer(serializers.HyperlinkedModelSerializer):
+    password = serializers.CharField(
+        write_only=True, required=True, style={"input_type": "password"}
+    )
+
     class Meta:
         model = User
-        fields = ["url", "username", "email"]
+        fields = ["url", "username", "email", "password"]
+
+    def create(self, validated_data):
+        validated_data["password"] = make_password(
+            validated_data.get("password")
+        )
+        return super(UserSerializer, self).create(validated_data)
 
 
 class NoteSerializer(serializers.HyperlinkedModelSerializer):

--- a/app/notes/tests.py
+++ b/app/notes/tests.py
@@ -322,3 +322,35 @@ class NoteVisibilityCase(TestCase):
         assert first["url"] == url_for_note(self.note_1_1, True)
         assert second["url"] == url_for_note(self.note_1_2, True)
         assert third["url"] == url_for_note(self.note_2_2, True)
+
+
+class UserManagementCase(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+
+    def test_unauthenticated_user_can_create_account(self):
+        payload = {
+            "username": "new",
+            "password": "pass",
+            "email": "new@example.com",
+        }
+        response = self.client.post("/users/", payload)
+        assert response.status_code == 201
+        new_user = User.objects.get(username=payload["username"])
+        assert new_user.username == payload["username"]
+        assert new_user.email == payload["email"]
+
+    def test_authenticated_user_can_not_create_account(self):
+        user_1 = User.objects.create(
+            username="user1", email="user1@example.com"
+        )
+        self.client.force_authenticate(user_1)
+        payload = {
+            "username": "new",
+            "password": "pass",
+            "email": "new@example.com",
+        }
+        response = self.client.post("/users/", payload)
+        assert response.status_code == 403
+        with self.assertRaises(User.DoesNotExist):
+            User.objects.get(username=payload["username"])

--- a/app/notes/views.py
+++ b/app/notes/views.py
@@ -4,7 +4,7 @@ from django_filters import rest_framework as df_filters
 from django.db.models import Q
 from .serializers import UserSerializer, NoteSerializer
 from .models import Note
-from .permissions import IsAuthenticatedOrPublic, IsSelf
+from .permissions import IsAuthenticatedOrPublic, UserPermission
 
 
 class UserViewSet(viewsets.ModelViewSet):
@@ -14,7 +14,7 @@ class UserViewSet(viewsets.ModelViewSet):
 
     queryset = User.objects.all().order_by("-date_joined")
     serializer_class = UserSerializer
-    permission_classes = [IsSelf]
+    permission_classes = [UserPermission]
 
 
 class NoteViewSet(viewsets.ModelViewSet):


### PR DESCRIPTION
## Scope

- Allow non-authenticated users to sign up for new user accounts
- Passwords are write-only and properly hashed

## Out of scope

- The `users` collection is still public, including potentially sensitive PII. Ideally, global user discovery should either be impossible or at least opt-in.
- No secondary email validation / address confirmation yet. User accounts can currently be used right after registering, which opens up the potential for abuse.
- No abuse protection (captcha, rate limit, cross-validation with breached credentials…) yet
- Password change / reset flow not implemented yet

## How to test / reproduce

1. Make a `POST` request against `/users/` and pass the following payload: `{"username": "<your new user name>", "email": "<your email address", "password": "<your new password>"}`
2. Log in with your new credentials

## Scouting 🏕️

- The `IsSelf` permission has been renamed to `UserPermission`, which might be a bit more intuitive than the previous name.

## Review checklist

- [x] PR is ready
    - PR is split into meaningful commits (if needed) for the ease of reviewing
    - Description contains clear instructions on how to test the feature
- [x] Tests have been written
- [x] Appropriate labels have been applied
